### PR TITLE
fix(website): fix filtering of edition data ids

### DIFF
--- a/assets/js/edition-outline.js
+++ b/assets/js/edition-outline.js
@@ -31,7 +31,7 @@ document.addEventListener('DOMContentLoaded', function () {
 function getChildren(parentNode) {
     const parentNodeId = parentNode.dataset.id;
     const childNodes = EDITION_DATA.nodes
-        .filter(node => node.parent_id === parentNodeId)
+        .filter(node => node.parent_id === parseInt(parentNodeId, 10))
         .sort((a, b) => a.sort - b.sort);
     if (childNodes.length > 0) {
         addChildren(parentNode, childNodes);


### PR DESCRIPTION
This PR fixes the filter method in the `edition-outline.js` file that finds all the children of a parent node. The parent node is retrieved as string from the HTML and needs to be converted to an integer before comparison.