### PR TITLE
fix(assets): add back lost bib file

### DIFF
--- a/assets/documents/AWG.bib
+++ b/assets/documents/AWG.bib
@@ -1,0 +1,800 @@
+% This file was created with Citavi 5.7.1.0
+% Creation date: 12.04.2018
+
+@incollection{Ahrend_2011,
+ author = {Ahrend, Thomas},
+ title = {{Zu Anton Weberns George-Vertonung 'Erwachen aus dem tiefsten Traumesschoße'. Eine Spurensuche}},
+ pages = {53–73},
+ publisher = {Schott},
+ editor = {Hohmaier, Simone},
+ booktitle = {{Jahrbuch 2011 des Staatlichen Instituts f{\"u}r Musikforschung Preu{\ss}ischer Kulturbesitz}},
+ year = {2011},
+ address = {Mainz}
+}
+
+
+@article{Ahrend_2012,
+ author = {Ahrend, Thomas},
+ year = {2012},
+ title = {{[Rezension von:] Dominik Schweiger und Nikolaus Urbanek (Hg.): \textit{webern{\_}21}. Wiener Ver{\"o}ffentlichungen zur Musikgeschichte 8. B{\"o}hlau Verlag. Wien 2009. 392 Seiten}},
+ pages = {213–228},
+ volume = {264},
+ number = {3–4},
+ journal = {{G{\"o}ttingische Gelehrte Anzeigen}}
+}
+
+
+@incollection{Ahrend_2015a,
+ abstract = {The distinction and possible tensions between the written score and a performance of a work is a medial characteristic of so called western art music. Furthermore »music« can be written down with regard to several functions, e.g. to sketch a compositional idea or to serve as a performance score. But different kinds of (written) musical sources do not always function in a categorized way that would allow a clear distinction for instance between »draft« and »elaboration«, but are often interrelated in a much more complex manner that hints among other things at the processual character of composition. In a first part of this paper the various surviving sources to Webern’s String Quartet (1905) are described in this respect. In a second part an analysis of a certain compositional detail (concerning the conception of the quartet as a sonata form) is proposed that refers to some observations in the sketches and the »Form-Entwurf«.},
+ author = {Ahrend, Thomas},
+ title = {{Entwurf oder Ausarbeitung? Die Quellen zu Anton Weberns \textit{Streichquartett (1905)}}},
+ pages = {316–332},
+ publisher = {Laaber},
+ series = {Musiktheorie},
+ editor = {Ahrend, Thomas and Schmidt, Matthias},
+ booktitle = {{Anton Webern und Giovanni Segantini}},
+ year = {2015},
+ address = {Laaber},
+ volume = {30/4}
+}
+
+
+@incollection{Ahrend_2015b,
+ author = {Ahrend, Thomas},
+ title = {{Hausaufgabe und Werk. Zur Formkonzeption von Anton Weberns \textit{Langsamem Satz} f{\"u}r Streichquartett}},
+ pages = {71–89},
+ publisher = {Lafite},
+ isbn = {978-3-85151-083-6},
+ series = {Webern-Studien},
+ editor = {Ahrend, Thomas and Schmidt, Matthias},
+ booktitle = {{Der junge Webern. Texte und Kontexte}},
+ year = {2015},
+ address = {Wien},
+ volume = {2b}
+}
+
+
+@incollection{Ahrend_2016a,
+ abstract = {In his songs composed on poems by Stefan George Anton Webern first adopted spelling peculiarities in these texts in the manuscripts prior to publication. Later and particularly in prints the spelling was normalized by Webern or with his agreement. The projected historical-critical edition of early versions and the unpublished songs during Webern’s lifetime within the Anton Webern Gesamtausgabe (Basel) faces specific problems in this context due to the inconsistent and sometimes ambiguous adoption of the characteristics in George’s spelling in the sources. In some cases even deciphering the reading of a single capital or lowercase letter would be an interpretation or would have to be based on interpretations of other passages in the same or other songs.},
+ author = {Ahrend, Thomas},
+ title = {{Editorische Probleme des vertonten Textes in Anton Weberns George-Vertonungen. Beispiele zur aktuellen Arbeit an der Anton Webern Gesamtausgabe}},
+ pages = {199–211},
+ publisher = {{Peter Lang}},
+ editor = {Zoppelli, Luca},
+ booktitle = {{Schweizer Jahrbuch f{\"u}r Musikwissenschaft. Neue Folge 33 (2013)}},
+ year = {2016},
+ address = {Bern},
+ url = {https://edoc.unibas.ch/40265/2/20151216140935_5671628f398d1.pdf}
+}
+
+
+@article{Ahrend_2016b,
+ author = {Ahrend, Thomas},
+ year = {2016},
+ title = {{'Vielen Dank f{\"u}r Ihre sch{\"o}nen Lieder'. Hanns Eislers Klavierlieder op. 2 im Kontext seines Unterrichtes bei Anton Webern}},
+ pages = {10–14},
+ volume = {61},
+ journal = {{Eisler-Mitteilungen}}
+}
+
+
+@article{Ahrend_2017,
+ abstract = {Despite the lack of any musical dramatic works in Anton Webern’s oeuvre, his music is often labeled as "gestural": for example, in the famous foreword of Arnold Schoenberg to Webern’s Bagatellen, Op. 9, or in some of Theodor W. Adorno’s writings. The latter’s polarizing characterization of Webern’s (early) gestural pieces as "absolute expression" ("absoluter Ausdruck"), on the one side, and his (late) twelve-note compositions as a mere "fetishism of material" ("Materialfetischismus"), on the other, raises the question of how one could nevertheless describe Webern’s late music as expressive or affective. Referring to the concepts of "affection-image" and "crystal-image" in Gilles Deleuze’s Cinema-books, this essay tries to discuss (in an experimental way) Webern’s Bagatelle, Op. 9/III as a possible 'affection sound' (Affektklang), and the second movement of the Konzert, Op. 24 as a 'crystal sound' (Kristallklang), both pieces realizing different types or modes of musical expression.},
+ author = {Ahrend, Thomas},
+ year = {2017},
+ title = {{'… einen Roman durch eine einzige Geste … auszudr{\"u}cken …' Affekt- und Kristallkl{\"a}nge bei Anton Webern}},
+ pages = {21–41},
+ volume = {31},
+ number = {1},
+ journal = {{Musiktheorie}}
+}
+
+
+@article{Ahrend_2017b,
+ author = {Ahrend, Thomas and L{\"u}cker, Arno},
+ year = {2017},
+ date = {23.08.2017},
+ title = {{What's Up With Webern}},
+ urlOnline_Article = {https://van.atavist.com/hot-webern},
+ journal = {{VAN. Webmagazin f{\"u}r klassische Musik}}
+}
+
+
+@incollection{Ahrend_2018a,
+ author = {Ahrend, Thomas},
+ title = {{'Heftige Bewegungen der Seele, die doch sehr leise sind'. Zum Bearbeitungsprozess von Anton Weberns Rilke-Liedern op. 8}},
+ pages = {102–110},
+ publisher = {Schott},
+ isbn = {978-3-7957-9885-7},
+ editor = {Obert, Simon and Zimmermann, Heidy},
+ booktitle = {{RE-SET. R{\"u}ckgriffe und Fortschreibungen in der Musik seit 1900}},
+ year = {2018},
+ address = {Mainz}
+}
+
+
+@incollection{Ahrend_2018b,
+ author = {Ahrend, Thomas},
+ title = {{Noten-Pausen-Schrift-Zeichen-Medium. (Differenztheoretische) {\"U}berlegungen zur Notation von 'stiller Musik'}},
+ pages = {188–212},
+ publisher = {Pfau},
+ editor = {Schmusch, Rainer and Ullmann, Jakob},
+ booktitle = {stille | musik},
+ isbn = {978-3-89727-546-1},
+ year = {2018},
+ address = {B{\"u}dingen}
+}
+
+
+@incollection{Ahrend_2018c,
+ abstract = {According to Adorno, Anton Webern’s atonal compositions are considered 'absolute lyricism', i.e. the expression of an inwardness (Innerlichkeit). Using the example of an early piano song by Webern, the concept of mood (Stimmung) is used to analyze which compositional features construct an inwardness already in this tonal work. The specific inwardness of Webern’s song is illustrated by a comparison with Max Reger’s setting to music of the same poem.},
+ author = {Ahrend, Thomas},
+ title = {{Innerlichkeit und Stimmung in Anton Weberns \textit{Fromm} (1902)}},
+ pages = {197–215},
+ publisher = {Hollitzer},
+ isbn = {978-3-99012-535-9},
+ editor = {Gasch, Stefan},
+ booktitle = {{Ästhetik der Innerlichkeit. Max Reger und das Lied um 1900}},
+ series = {Wiener Veröffentlichungen zur Musikwissenschaft 48},
+ year = {2018},
+ address = {Wien}
+}
+
+
+@incollection{Ahrend_2019a,
+ abstract = {[Der Text] setzt sich mit den beiden grundlegenden Begriffen "Interpretation" und "Performativität" im Lichte der Differenz zwischen Text und Ereignis auseinander. Ahrend plädiert dafür, dieses Begriffspaar nicht als starren Antagonismus zu begreifen, sondern das analytische Augenmerk auf dynamische Prozesse der wechselseitigen Verschränkung und Durchdringung zu richten, die von Fall zu Fall jeweils wieder neu ausgehandelt werden. Dass sich musikalische Stimmaufführungen keinesfalls so eindeutig wie oft implizit unterstellt entweder als text- oder aber als ereignisorientiert kategorisieren lassen, belegt Ahrend anhand einer Gegenüberstellung von zwei denkbar gegensätzlichen Beispielen, deren genaue Betrachtung scheinbar unverrückbare kontextbezogene Denkmuster ins Wanken bringt. So arbeitet Ahrend einerseits Momente einer ins Offene fortschreibbaren Prozesshaftigkeit in Anton Webers Vokalkomposition "Dies ist ein Lied" heraus, die sich hinter einer vorgeblich definitiven (und imperativen) Werkgestalt verbirgt. Im Gegenzug zeigt er am Beispiel des Songs "When the Music's Over" von The Doors auf, dass das scheinbar vorrangig situationsbedingte, spontane Geschehen eines Popkonzerts auf stabilen, genau kalkulierten kompositorischen Rahmensetzungen basiert, die trotz meist fehlender Verschrifllichung durchaus Werkcharakter aufweisen. [Vorwort der Herausgeber, S. 10]},
+ author = {Ahrend, Thomas},
+ title = {{Interpretierst du noch oder performst du schon? Überlegungen zu einer Begrifflichkeit}},
+ pages = {19–29},
+ publisher = {Pfau},
+ isbn = {978-3-89727-550-8},
+ editor = {Krüger, Anne-May and Dick, Leo},
+ booktitle = {{Performing Voice. Vokalität im Fokus angewandter Interpretationsforschung}},
+ year = {2019},
+ address = {Büdingen}
+}
+
+
+@incollection{Ahrend_2019b,
+ author = {Ahrend, Thomas},
+ title = {{Weberns Sch{\"u}ler. Zum Beispiel: Hanns Eisler, Ludwig Zenk und Leopold Spinner}},
+ pages = {27–50},
+ publisher = {Lafite},
+ isbn = {978-3-85151-098-0},
+ series = {Webern-Studien},
+ editor = {Cavallotti, Pietro and Obert, Simon and Schmusch, Rainer},
+ booktitle = {{Neue Perspektiven. Anton Webern und das Komponieren im 20. Jahrhundert}},
+ year = {2019},
+ address = {Wien},
+ volume = {4}
+}
+
+@incollection{Ahrend_2022,
+ author = {Ahrend, Thomas},
+ editor = {Wörner, Felix and Wald-Fuhrmann, Melanie},
+ booktitle = {{Musikästhetik in Europa und Nordamerika}},
+ year = {2022},
+ title = {{Anton Webern: Wege zur neuen Musik}},
+ pages = {898–899},
+ address = {Kassel/München},
+ publisher = {Bärenreiter/Metzler},
+ series = {{Lexikon Schriften über Musik}},
+ volume = {2}
+}
+
+
+@incollection{Ahrend-Matter_2018,
+ author = {Ahrend, Thomas and Matter, Michael},
+ editor = {Heister, Hanns-Werner and Sparrer, Walter Wolfgang},
+ year = {2018},
+ title = {{Anton Webern}},
+ address = {München},
+ publisher = {Edition Text + Kritik},
+ series = {{Komponisten der Gegenwart (KDG)}},
+ urlOnline_Article = {http://www.munzinger.de/document/17000000630},
+ note = {61. und 62. Nflg.}
+}
+
+@incollection{Ahrend-Muennich_2018,
+ author = {Ahrend, Thomas and Münnich, Stefan},
+ editor = {Gustafson, Bruce},
+ year = {2018},
+ title = {{Anton Webern}},
+ address = {New York/Oxford},
+ publisher = {Oxford University Press},
+ series = {{Oxford Bibliographies in Music}},
+ doi = {10.1093/obo/9780199757824-0238},
+ note = {Online-Publikation.}
+}
+
+
+@book{Ahrend-Schmidt_2015a,
+ year = {2015},
+ title = {\textit{Anton Webern und Giovanni Segantini}},
+ address = {Laaber},
+ volume = {30/4},
+ publisher = {Laaber},
+ series = {{Musiktheorie}},
+ editor = {Ahrend, Thomas and Schmidt, Matthias}
+}
+
+
+@book{Ahrend-Schmidt_2015b,
+ year = {2015},
+ title = {\textit{Der junge Webern. Texte und Kontexte}},
+ address = {Wien},
+ volume = {2b},
+ publisher = {Lafite},
+ isbn = {978-3-85151-083-6},
+ series = {{Webern-Studien}},
+ editor = {Ahrend, Thomas and Schmidt, Matthias}
+}
+
+
+@book{Ahrend-Schmidt_2016,
+ year = {2016},
+ title = {\textit{Webern-Philologien}},
+ address = {Wien},
+ volume = {3},
+ publisher = {Lafite},
+ isbn = {978-3-85151-084-3},
+ series = {{Webern-Studien}},
+ editor = {Ahrend, Thomas and Schmidt, Matthias}
+}
+
+
+@article{Ahrend-Ziegler_2020,
+ author = {Ahrend, Thomas and Ziegler, Michelle},
+ year = {2020},
+ title = {{Anton Webern: \textit{Dies ist ein Lied} M 133. Impuls [Ahrend]: Flüchtige Reinschrift oder sorgfältige Skizze? Überlegungen zu Anton Weberns frühester Niederschrift von \textit{Dies ist ein Lied} M 133. Respondenz [Ziegler]: Bleistiftglück und Tintenbestimmtheit. Gedanken zu den Schreibstoffen im Kompositionsprozess von Anton Weberns \textit{Dies ist ein Lied}}},
+ pages = {162–182},
+ volume = {17},
+ journal = {{Journal of the Arnold Schönberg Center}}
+}
+
+
+@book{Bungardt_2020,
+ year = {2020},
+ title = {\textit{Briefwechsel mit der Universal-Edition}},
+ address = {Wien},
+ volume = {5},
+ publisher = {Lafite},
+ isbn = {978-3-85151-102-4},
+ series = {{Webern-Studien}},
+ editor = {Bungardt, Julia}
+}
+
+
+@book{Cavallotti-Obert-Schmusch_2019,
+ year = {2019},
+ title = {\textit{Neue Perspektiven. Anton Webern und das Komponieren im 20. Jahrhundert}},
+ address = {Wien},
+ volume = {4},
+ publisher = {Lafite},
+ isbn = {978-3-85151-098-0},
+ series = {{Webern-Studien}},
+ editor = {Cavallotti, Pietro and Obert, Simon and Schmusch, Rainer}
+}
+
+
+@book{Kroepfl-Obert_2015a,
+ year = {2015},
+ title = {\textit{Der junge Webern. K{\"u}nstlerische Orientierungen in Wien nach 1900}},
+ address = {Wien},
+ volume = {2a},
+ publisher = {Lafite},
+ series = {{Webern-Studien}},
+ editor = {Kr{\"o}pfl, Monika and Obert, Simon}
+}
+
+
+@incollection{Kroepfl-Obert_2015b,
+ author = {Kr{\"o}pfl, Monika and Obert, Simon},
+ title = {{'Nur der Kunst'. Eine Standortbestimmung des jungen Webern}},
+ pages = {9–20},
+ publisher = {Lafite},
+ series = {Webern-Studien},
+ editor = {Kr{\"o}pfl, Monika and Obert, Simon},
+ booktitle = {{Der junge Webern. K{\"u}nstlerische Orientierungen in Wien nach 1900}},
+ year = {2015},
+ address = {Wien},
+ volume = {2a}
+}
+
+
+@incollection{Matter_2017a,
+ author = {Matter, Michael},
+ title = {{Anton Webern und die 'Gr{\"u}ndungsmythen' der Wiener Schule}},
+ pages = {223–235},
+ publisher = {{K{\"o}nigshausen {\&} Neumann}},
+ editor = {Wegner, Sascha},
+ booktitle = {{{\"U}ber den Ursprung von Musik. Mythen, Legenden und Geschichtsschreibungen}},
+ year = {2017},
+ address = {W{\"u}rzburg}
+}
+
+
+@incollection{Matter_2017b,
+ author = {Matter, Michael},
+ title = {{Revisionen in Anton Weberns Klavierst{\"u}cken aus der Studienzeit}},
+ pages = {271–281},
+ publisher = {{De Gruyter}},
+ isbn = {3-11-049571-6},
+ series = {Beihefte zu Editio},
+ editor = {Hofmeister, Wernfried and Hofmeister-Winter, Andrea and B{\"o}hm, Astrid},
+ booktitle = {{Textrevisionen. Beitr{\"a}ge der Internationalen Fachtagung der Arbeitsgemeinschaft f{\"u}r germanistische Edition, Graz, 17. bis 20. Februar 2016}},
+ year = {2017},
+ address = {Berlin},
+ volume = {41}
+}
+
+
+@article{Matter-Busch_2020,
+ author = {Matter, Michael and Busch, Regina},
+ year = {2020},
+ title = {{Anton Webern: Klavierstück M 277. Impuls [Matter]: Weberns Frühphase der Zwölftontechnik: die Skizzen zum Klavierstück M 277. Respondenz [Busch]: Bemerkungen zum Klavierstück M 277 im Kontext des Skizzenbuch Nr. 1}},
+ pages = {200–219},
+ volume = {17},
+ journal = {{Journal of the Arnold Schönberg Center}}
+}
+
+
+@misc{Muennich_2016a,
+ abstract = {Die virtuelle Forschungsplattform SALSAH (System for Annotation and Linkage of Sources in Arts and Humanities) ermöglicht sowohl die Erzeugung, Bearbeitung und Verkn{\"u}pfung von Daten und Inhalten als auch deren Präsentation in ein und derselben Umgebung. Ihre hierarchisierbare Datenmodellierung beg{\"u}nstigt die Herausbildung eines 'semantic web' aus digitalen Objekten mit ihren jeweiligen Annotationen und Verkn{\"u}pfungen. Die an der Universität Basel ansässige Anton Webern-Gesamtausgabe nutzt diesen Ansatz f{\"u}r ihre historisch-kritische Edition des musikalischen Werks Anton Weberns gleich mehrfach: als Quellenarchiv, als Dokumentationsdatenbank sowie als editionspraktisches Arbeitswerkzeug. Die Posterpräsentation soll die strukturelle Konzeption f{\"u}r die Einbindung einer (musik-)wissenschaftlichen Edition in eine solche virtuelle Forschungsumgebung veranschaulichen.},
+ author = {M{\"u}nnich, Stefan},
+ year = {2016},
+ title = {{Eine musikwissenschaftliche Edition in virtueller Umgebung. Die Einbindung der Anton Webern-Gesamtausgabe in SALSAH [Poster]}},
+ url = {http://www.anton-webern.ch/assets/documents/Münnich_Poster_AWG_DHd2016.pdf},
+ urlConference_Abstract = {http://www.dhd2016.de/abstracts/posters-029.html}, 
+ institution = {{"Digital Humanities im deutschsprachigen Raum e. V." (DHd)}},
+ note = {3. Tagung des Verbands „Digital Humanities im deutschsprachigen Raum e. V.“ (DHd):  „Modellierung – Vernetzung – Visualisierung. Die Digital Humanities als fächer{\"u}bergreifendes Forschungsparadigma“, 7.–12. März 2016, Universität Leipzig.}
+}
+
+
+@misc{Muennich_2016b,
+ abstract = {The virtual research platform SALSAH (System for Annotation and Linkage of Sources in Arts and Humanities) allows both the production, processing and linking of data and content as well as their presentation in the same environment. Its hierarchically structured data model creates a 'semantic web' of digital objects with their annotations and links. Based at the University of Basel, Switzerland, the Anton Webern Gesamtausgabe uses this approach for a historical-critical edition of the musical oeuvre of Anton Webern in several ways: as a source archive, as documentation database as well as a practical tool for the philological work. The poster presentation is intended to illustrate the structural and methodical design for the integration of a (music) scientific edition in such a virtual research environment.},
+ author = {M{\"u}nnich, Stefan},
+ year = {2016},
+ title = {{A Musicological Edition in a Virtual Environment: Integrating the Anton Webern Gesamtausgabe in SALSAH [Poster]}},
+ url = {http://www.anton-webern.ch/assets/documents/Münnich_Poster_AWG_MEC2016.pdf},
+ institution = {{„Music Encoding Conference“ (MEC2016)}},
+ note = {„Music Encoding Conference“ (MEC2016), 17.–20. Mai 2016, Schulich School of Music, McGill University, Montréal (CA).}
+}
+
+
+@article{Muennich_2018a,
+ abstract = {Ontologien spielen eine zentrale Rolle f{\"u}r die formalisierte Repräsentation von Wissen und Informationen sowie f{\"u}r die Infrastruktur des sogenannten semantic web. Trotz fr{\"u}herer Initiativen der Bibliotheken und Gedächtnisinstitutionen  hat  sich  die  deutschsprachige Musikwissenschaft insgesamt nur sehr zögerlich dem Thema genähert. Im Rahmen einer Bestandsaufnahme werden neben der Erläuterung grundlegender Konzepte, Herausforderungen und Herangehensweisen bei der Modellierung von Ontologien daher auch vielversprechende Modelle und bereits erprobte Anwendungsbeispiele f{\"u}r eine ‚semantische‘ digitale Musikwissenschaft identifiziert.},
+ author = {M{\"u}nnich, Stefan},
+ year = {2018},
+ title = {{Ontologien als semantische Z{\"u}ndstufe f{\"u}r die digitale Musikwissenschaft? Eine Bestandsaufnahme}},
+ pages = {184–193},
+ volume = {42},
+ number = {2},
+ journal = {{BIBLIOTHEK – Forschung und Praxis}},
+ doi = {10.1515/bfp-2018-0027},
+ url = {https://www.degruyter.com/downloadpdf/j/bfup.2018.42.issue-2/bfp-2018-0027/bfp-2018-0027.pdf}
+}
+
+
+@article{Muennich_2018b,
+ abstract = {The processing, dissemination, classification and verifiability of "resilient" knowledge represents some of the most pressing challenges facing society as a whole in this still young digital age. Information-theoretical ontologies that are integrated into the vision of the so-called semantic web can be of great use here. On the basis of application examples as well as the explanation of basic concepts, mechanisms and challenges for the systematization and modelling of knowledge structures, the current possibilities for a "semantic" digital musicology are shown.},
+ author = {Münnich, Stefan},
+ year = {2018},
+ title = {{Ontologien in der Praxis: Möglichkeiten und Herausforderungen für die Modellierung musikwissenschaftlicher/musikeditorischer Wissensstrukturen}},
+ pages = {319–337},
+ volume = {71},
+ number = {4},
+ journal = {{Die Musikforschung}}
+}
+
+@incollection{Muennich_2019,
+ abstract = {The paper approaches the problem of the loss of sources (deperdita) from three different perspectives: In a first section, deperdita are identified as a methodological area of uncertainty for historical research and possible categorisations are proposed. The following case study from the work of the Anton Webern Gesamtausgabe illustrates the consequences of such defects in cultural memory caused by missing sources, before proposals for graph-based modeling of negations and deperdita are presented in the last part. The aim of the discussion is to raise awareness of the challenges involved in dealing with historical material that is no longer available and for a constructive and productive approach to uncertainties.},
+ author = {M{\"u}nnich, Stefan},
+ title = {{Quellenverluste (Deperdita) als methodologischer Unsicherheitsbereich für Editorik und Datenmodellierung am Beispiel von Anton Weberns George-Lied op. 4 Nr. 5}},
+ booktitle = {{Die Modellierung des Zweifels – Schlüsselideen und -konzepte zur graphbasierten Modellierung von Unsicherheiten}},
+ editor = {Kuczera, Andreas and Wübbena, Thorsten and Kollatz, Thomas},
+ address = {Wolfenb{\"u}ttel},
+ year = {2019},
+ series = {{Zeitschrift für digitale Geisteswissenschaften / Sonderb{\"a}nde}},
+ volume = {4},
+ doi = {10.17175/sb004_005},
+ url = {http://www.zfdg.de/sb004_005}
+}
+
+@incollection{Muennich_2021,
+ author = {Münnich, Stefan and Ahrend, Thomas},
+ title = {{Scholarly Music Editions as Graph: Semantic Modelling of the Anton Webern Gesamtausgabe}},
+ pages = {155–180},
+ publisher = {{BoD – Books on Demand}},
+ isbn = {978-3-7543-4369-2},
+ series = {{Schriftenreihe des Instituts für Dokumentologie und Editorik}},
+ editor = {Spadini, Elena and Tomasi, Francesca and Vogeler, Georg},
+ booktitle = {{Graph Data-Models and Semantic Web Technologies in Scholarly Digital Editing}},
+ year = {2021},
+ address = {Norderstedt}
+}
+
+@incollection{Muennich_2023a,
+ author = {Münnich, Stefan},
+ title = {Handwritten – Encoded – Semantically Operationalised: Musical Writing Scenes in the Digital Realm},
+ pages = {371--391},
+ publisher = {{Brill | Fink}},
+ isbn = {9783770567140},
+ series = {Theorie der musikalischen Schrift},
+ volume = {4},
+ editor = {Celestini, Federico and Lutz, Sarah},
+ booktitle = {Musikalische Schreibszenen / Scenes of Musical Writing},
+ year = {2023},
+ address = {Paderborn},
+ doi = {10.30965/9783846767146_016}
+}
+
+@inproceedings{Muennich_2023b,
+ abstract = {Digital music writing encodings pose challenges: They force us to question, rethink and renegotiate the concept of musical writing and notation which has shaped the historiography of music in the Latin-Western cultural sphere since its beginnings. How can digital forms of musical writing be integrated into and theoretically addressed by a concept of writing? Are writing and notation the same? What are the similarities, what the differences between historical and contemporary forms of music writing? Following a terminological clarification of the relevant concepts, this paper will approach these questions from a sign-theoretical perspective by contrasting the (non-music-specific) notation models of Nelson Goodman and Roy Harris and examining their suitability as possible descriptive models in connection with musical notation. Finally, with the concept of musical notation developed from this model, some nowadays commonly used music encoding formats (MEI, Lilypond, and MusicOWL) will briefly be considered. Ultimately, the questions raised are intended to illuminate a sub-area of that medial area of tension which the notation of music still opens up in various ways, time and again.},
+ author = {Münnich, Stefan},
+ title = {Zwischen Federkiel und digitaler Codierung. Musikalische Schrift als mediales Spannungsfeld},
+ pages = {35–68},
+ series = {GMTH Proceedings 2019},
+ editor = {Kocher, Philippe},
+ booktitle = {Notation. Schnittstelle zwischen Komposition, Interpretation und Analyse},
+ year = {2023},
+ doi = {10.31751/p.256}
+}
+
+@article{Obert_2007,
+ author = {Obert, Simon},
+ year = {2007},
+ title = {{Anton Webern 1924 in Donaueschingen. Zur Urauff{\"u}hrung der \textit{Sechs Bagatellen f{\"u}r Streichquartett} op. 9 und der \textit{Sechs Lieder nach Gedichten von Georg Trakl} op. 14}},
+ pages = {176–190},
+ volume = {22},
+ number = {2},
+ journal = {{Musiktheorie}}
+}
+
+
+@book{Obert_2008a,
+ author = {Obert, Simon},
+ year = {2008},
+ title = {\textit{Musikalische K{\"u}rze zu Beginn des 20. Jahrhunderts. Zugl.: Diss. Universit{\"a}t Basel, 2006}},
+ address = {Stuttgart},
+ volume = {63},
+ publisher = {Steiner},
+ isbn = {978-3515091534},
+ series = {{Beihefte zum Archiv f{\"u}r Musikwissenschaft}}
+}
+
+
+@incollection{Obert_2008b,
+ author = {Obert, Simon},
+ title = {{Synchroner Schnitt um 1910. Das kurze St{\"u}ck im musikkulturellen Kontext}},
+ pages = {391–402},
+ publisher = {Weidler},
+ isbn = {978-3-89693-515-1},
+ series = {Musik und. Neue Folge},
+ editor = {Sprick, Jan Philipp and Bahr, Reinhard and von Troschke, Michael},
+ booktitle = {{Musiktheorie im Kontext. 5. Kongress der Gesellschaft f{\"u}r Musiktheorie, Hamburg 2005}},
+ year = {2008},
+ address = {Berlin},
+ volume = {9}
+}
+
+
+@incollection{Obert_2010,
+ author = {Obert, Simon},
+ title = {{Aufbruch zur Gegenwart. Die Donaueschinger Kammermusiktage 1921-1926}},
+ pages = {241–245},
+ publisher = {{Der Kleine Buch Verlag}},
+ isbn = {978-3937345437},
+ editor = {{Badisches Landesmuseum Karlsruhe}},
+ booktitle = {{Vom Minnesang zur Popakademie. Musikkultur in Baden-W{\"u}rttemberg}},
+ year = {2010},
+ address = {Karlsruhe}
+}
+
+
+@book{Obert_2012a,
+ year = {2012},
+ title = {\textit{Wechselnde Erscheinung. Sechs Perspektiven auf Anton Weberns sechste Bagatelle}},
+ address = {Wien},
+ volume = {1},
+ publisher = {Lafite},
+ isbn = {978-3-85151-080-5},
+ series = {{Webern-Studien}},
+ editor = {Obert, Simon}
+}
+
+
+@incollection{Obert_2012b,
+ author = {Obert, Simon},
+ title = {{'Der unfa{\ss}liche Zustand'. Fragen an Weberns sechste Bagatelle}},
+ pages = {11–35},
+ publisher = {Lafite},
+ isbn = {978-3-85151-080-5},
+ series = {Webern-Studien},
+ editor = {Obert, Simon},
+ booktitle = {{Wechselnde Erscheinung. Sechs Perspektiven auf Anton Weberns sechste Bagatelle}},
+ year = {2012},
+ address = {Wien},
+ volume = {1}
+}
+
+
+@article{Obert_2012c,
+ author = {Obert, Simon},
+ year = {2012},
+ title = {{On the Top of the Empire State Building. Zur diskreten Beziehung des Pop zu Anton Webern}},
+ pages = {46–48},
+ volume = {173},
+ number = {6},
+ journal = {{Neue Zeitschrift f{\"u}r Musik}}
+}
+
+
+@article{Obert_2015a,
+ author = {Obert, Simon},
+ year = {2015},
+ title = {{'… die Konsequenzen ziehe ich …' Ein neu aufgefundener Brief von Sch{\"o}nberg an Webern}},
+ pages = {37–42},
+ volume = {28},
+ journal = {{Mitteilungen der Paul Sacher Stiftung}}
+}
+
+
+@incollection{Obert_2015b,
+ author = {Obert, Simon},
+ title = {{Weberns fr{\"u}he Instrumentationen}},
+ pages = {113–127},
+ publisher = {Lafite},
+ isbn = {978-3-85151-083-6},
+ series = {Webern-Studien},
+ editor = {Ahrend, Thomas and Schmidt, Matthias},
+ booktitle = {{Der junge Webern. Texte und Kontexte}},
+ year = {2015},
+ address = {Wien},
+ volume = {2b}
+}
+
+
+@incollection{Obert_2016a,
+ author = {Obert, Simon},
+ title = {{Anton Webern. 'Aus Sch{\"o}nberg Schriften'}},
+ pages = {53–55},
+ publisher = {Schott},
+ isbn = {978-3-7957-1202-0},
+ editor = {{Paul Sacher Stiftung}},
+ booktitle = {{"On revient toujours". Dokumente zur Sch{\"o}nberg-Rezeption aus der Paul Sacher Stiftung. Festgabe f{\"u}r Hermann Danuser zum 70. Geburtstag}},
+ year = {2016},
+ address = {Mainz}
+}
+
+
+@incollection{Obert_2016b,
+ author = {Obert, Simon},
+ title = {{Anton Webern. Bearbeitung der Kammersymphonie op. 9}},
+ pages = {29–32},
+ publisher = {Schott},
+ isbn = {978-3-7957-1202-0},
+ editor = {{Paul Sacher Stiftung}},
+ booktitle = {{"On revient toujours". Dokumente zur Sch{\"o}nberg-Rezeption aus der Paul Sacher Stiftung. Festgabe f{\"u}r Hermann Danuser zum 70. Geburtstag}},
+ year = {2016},
+ address = {Mainz}
+}
+
+
+@incollection{Obert_2016c,
+ author = {Obert, Simon},
+ title = {{Anton Webern. Bearbeitung des Vorspiels der \textit{Gurre-Lieder}}},
+ pages = {8–10},
+ publisher = {Schott},
+ isbn = {978-3-7957-1202-0},
+ editor = {{Paul Sacher Stiftung}},
+ booktitle = {{"On revient toujours". Dokumente zur Sch{\"o}nberg-Rezeption aus der Paul Sacher Stiftung. Festgabe f{\"u}r Hermann Danuser zum 70. Geburtstag}},
+ year = {2016},
+ address = {Mainz}
+}
+
+
+@incollection{Obert_2016d,
+ author = {Obert, Simon},
+ title = {{Freie Typographia. Konzertprogramm 7. und 14. April 1929}},
+ pages = {38–39},
+ publisher = {Schott},
+ isbn = {978-3-7957-1202-0},
+ editor = {{Paul Sacher Stiftung}},
+ booktitle = {{"On revient toujours". Dokumente zur Sch{\"o}nberg-Rezeption aus der Paul Sacher Stiftung. Festgabe f{\"u}r Hermann Danuser zum 70. Geburtstag}},
+ year = {2016},
+ address = {Mainz}
+}
+
+@incollection{Obert_2019,
+ author = {Obert, Simon},
+ title = {{On the Top of the Empire State Building. Zur diskreten Beziehung des Pop zu Anton Webern}},
+ pages = {305–310},
+ publisher = {Lafite},
+ isbn = {978-3-85151-098-0},
+ series = {Webern-Studien},
+ editor = {Cavallotti, Pietro and Obert, Simon and Schmusch, Rainer},
+ booktitle = {{Neue Perspektiven. Anton Webern und das Komponieren im 20. Jahrhundert}},
+ year = {2019},
+ address = {Wien},
+ volume = {4},
+ note = {Erweiterter Wiederabdruck von Obert 2012c.}
+ }
+
+@incollection{Obert_2020a,
+ author = {Obert, Simon},
+ title = {{Anton Webern, Tagebucheintrag (1904)}},
+ pages = {66–69},
+ publisher = {{Schott}},
+ isbn = {978-3-7957-2156-5},
+ editor = {Meyer, Felix and Obert, Simon},
+ booktitle = {{Zündstoff Beethoven. Rezeptionsdokumente aus der Paul Sacher Stiftung}},
+ year = {2020},
+ address = {Mainz}
+}
+
+@incollection{Obert_2020b,
+ author = {Obert, Simon},
+ title = {{Anton Webern, Diary Entry (1904)}},
+ pages = {66–69},
+ publisher = {{Boydell}},
+ isbn = {978-1-7832-7590-8},
+ editor = {Meyer, Felix and Obert, Simon},
+ booktitle = {{Ignition: Beethoven – Reception Documents from the Paul Sacher Foundation}},
+ year = {2020},
+ address = {Woodbridge}
+}
+
+@incollection{Obert_2022,
+ author = {Obert, Simon},
+ title = {{Anton Webern 1924 in Donaueschingen. Zur Uraufführung der Sechs Bagatellen für Streichquartett op. 9 und der Sechs Lieder nach Gedichten von Georg Trakl op. 14}},
+ pages = {237–257},
+ publisher = {{Schwabe}},
+ series = {Resonanzen. Basler Publikationen zur Älteren und Neueren Musik},
+ isbn = {9978-3-7965-3753-0},
+ editor = {Obert, Simon and Schmidt, Matthias},
+ booktitle = {{Laboratorium der neuen Musik. Die Donaueschinger Kammermusiktage 1921–1926}},
+ year = {2022},
+ address = {Basel},
+ volume = {4},
+ note = {Erweiterte Fassung von Obert 2007.}
+}
+
+
+@book {Puffett-Schingnitz_2020,
+ abstract = {This book examines the relationship of three very different men who are usually seen as the most important composers of the so-called Second Viennese School – Arnold Schönberg, Alban Berg and Anton Webern – in the years 1906 to 1921 through a close reading of their correspondence with each other. To date only one of these correspondences, that of Schönberg and Berg, has been published, so the other two sets of letters are not yet widely known. The largely differing personalities of these three men come out clearly in their letters to each other: Schönberg, the master who demands a great many things from his two pupils (long after they have ceased to be that); Berg, from whom he demands the most; and Webern, his most pious devotee. The book covers the period linking the first correspondence between master and pupils in 1906 and the dissolution of the Verein für musikalische Privataufführungen in 1921, the period when these men were most closely bound together. [blurb]},    
+ author  = {Puffett, Kathryn and Schingnitz, Barbara},
+ title = {\textit{Three Men of Letters. Arnold Schönberg, Alban Berg and Anton Webern, 1906–1921}},
+ address = {Wien},
+ publisher = {Hollitzer},
+ year = {2020},
+ isbn = {978-3-99012-776-6}
+}
+
+@incollection{Schingnitz_2014,
+ author = {Schingnitz, Barbara},
+ title = {{Hildegard Jone und Anton Webern. Schlaglichter auf eine ungew{\"o}hnliche K{\"u}nstlerfreundschaft}},
+ pages = {18–21},
+ publisher = {{Stadtgemeinde Purkersdorf}},
+ booktitle = {{Hildegard Jone. Ihre Werke, ihr Leben. Symposium anl{\"a}sslich des 50. Todestages von Hildegard Jone (1891–1963)}},
+ year = {2014},
+ address = {Purkersdorf}
+}
+
+
+@incollection{Schingnitz_2016,
+ author = {Schingnitz, Barbara and Schweizer, Tobias},
+ title = {{Erarbeitung der Anton Webern Gesamtausgabe in einer digitalen Forschungsplattform}},
+ pages = {165–173},
+ publisher = {Lafite},
+ isbn = {978-3-85151-084-3},
+ series = {Webern-Studien},
+ editor = {Ahrend, Thomas and Schmidt, Matthias},
+ booktitle = {{Webern-Philologien}},
+ year = {2016},
+ address = {Wien},
+ volume = {3}
+}
+
+
+@incollection{Schmidt_2012,
+ author = {Schmidt, Matthias},
+ title = {{Ausdruck als Musik. Historisch-analytische Bemerkungen zu einer Viola-Gestalt Weberns}},
+ pages = {59–78},
+ publisher = {Lafite},
+ isbn = {978-3-85151-080-5},
+ series = {Webern-Studien},
+ editor = {Obert, Simon},
+ booktitle = {{Wechselnde Erscheinung. Sechs Perspektiven auf Anton Weberns sechste Bagatelle}},
+ year = {2012},
+ address = {Wien},
+ volume = {1}
+}
+
+
+@incollection{Schmidt_2015a,
+ abstract = {What did Webern motivate to relate sounding music to a real mountain landscape and the artificial imagery of Segantini’s »Alpentriptychon«? Why didn’t he make the apparent reference to Segantini as in his »Form-Entwurf« public in the subsequent autograph of the string quartet? The essay follows three traces seeking answers to these questions: First it explores the relevance of varieties of monism, which belonged directly to Weberns’s living environment, for his compositional aesthetic. Then it considers Webern’s studies with his teacher Arnold Schoenberg. Finally, based on some analytically detailed observations on Webern’s compositional practice it takes a closer look at his reception of Beethoven and the concept of the sublime. It is demonstrated how Segantini’s images as a representational medium for Webern mark a strategic transitional point between reality and art – in order to be absorbed in the ephemeral musical movement.},
+ author = {Schmidt, Matthias},
+ title = {{Fl{\"u}chtige Bilder. {\"U}ber Kunst und Wirklichkeit in Weberns 'Segantini-Quartett'}},
+ pages = {347–363},
+ publisher = {Laaber},
+ series = {Musiktheorie},
+ editor = {Ahrend, Thomas and Schmidt, Matthias},
+ booktitle = {{Anton Webern und Giovanni Segantini}},
+ year = {2015},
+ address = {Laaber},
+ volume = {30/4}
+}
+
+
+@incollection{Schmidt_2015b,
+ author = {Schmidt, Matthias},
+ title = {{Geschichtsstunde. Zur Historiographie Weberns und der Sch{\"o}nberg-Schule}},
+ pages = {51–70},
+ publisher = {Lafite},
+ isbn = {978-3-85151-083-6},
+ series = {Webern-Studien},
+ editor = {Ahrend, Thomas and Schmidt, Matthias},
+ booktitle = {{Der junge Webern. Texte und Kontexte}},
+ year = {2015},
+ address = {Wien},
+ volume = {2b}
+}
+
+
+@incollection{SchmidtM_2016,
+ author = {Schmidt, Matthias},
+ title = {{Zu einigen Voraussetzungen bei der Betrachtung eines Skizzenblattes von Anton Webern}},
+ pages = {9–26},
+ publisher = {Lafite},
+ isbn = {978-3-85151-084-3},
+ series = {Webern-Studien},
+ editor = {Ahrend, Thomas and Schmidt, Matthias},
+ booktitle = {{Webern-Philologien}},
+ year = {2016},
+ address = {Wien},
+ volume = {3}
+}
+
+
+@incollection{Urbanek_2009a,
+ author = {Urbanek, Nikolaus},
+ title = {{Titel aber plaudert aus oder Vom Verschweigen des Wesentlichen. Variationen über eine verschwiegene Frage zum Werk Anton Weberns}},
+ pages = {461–486},
+ publisher = {B{\"o}hlau},
+ isbn = {978-3205783893},
+ editor = {Bungardt, Julia and Helfgott, Maria and Rathgeber, Elke and Urbanek, Nikolaus},
+ booktitle = {{Wiener Musikgeschichte. Ann{\"a}herungen – Analysen – Ausblicke ; Festschrift f{\"u}r Hartmut Krones}},
+ year = {2009},
+ address = {Wien}
+}
+
+
+@incollection{Urbanek_2009b,
+ author = {Urbanek, Nikolaus},
+ title = {{'{\"O}ffentliche Einsamkeit'? Anmerkungen zum atonalen Liedschaffen Alban Bergs und Anton Weberns}},
+ pages = {95–121},
+ publisher = {Dohr},
+ isbn = {978-3-936655-73-5},
+ editor = {Heinemann, Michael and Hinrichsen, Hans-Joachim and Ottner, Carmen},
+ booktitle = {{{\"O}ffentliche Einsamkeit. Das deutschsprachige Lied und seine Komponisten im fr{\"u}hen 20. Jahrhundert}},
+ year = {2009},
+ address = {K{\"o}ln}
+}
+
+
+@incollection{Webern_2015,
+ author = {Webern, Anton and Schingnitz, Barbara},
+ title = {{Drei fr{\"u}he Tageb{\"u}cher. Transkribiert und kommentiert von Barbara Schingnitz}},
+ pages = {215–324},
+ publisher = {Lafite},
+ isbn = {978-3-85151-083-6},
+ series = {Webern-Studien},
+ editor = {Ahrend, Thomas and Schmidt, Matthias},
+ booktitle = {{Der junge Webern. Texte und Kontexte}},
+ year = {2015},
+ address = {Wien},
+ volume = {2b}
+}
+
+


### PR DESCRIPTION
This PR adds back the bib file that got lost in the export from the CMS.